### PR TITLE
fix: add rewriteRelativeImportExtensions to core build config

### DIFF
--- a/.changeset/fix-esm-extensions.md
+++ b/.changeset/fix-esm-extensions.md
@@ -1,0 +1,5 @@
+---
+"@rsc-boundary/core": patch
+---
+
+Fix ERR_MODULE_NOT_FOUND when consuming the package in Node ESM environments (e.g. TanStack Start) by enabling `rewriteRelativeImportExtensions` in the TypeScript build config. This ensures relative imports in emitted output have `.js` extensions as required by Node's ESM resolver.

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ pnpm remove rsc-boundary && pnpm add @rsc-boundary/start
 
 ## Packages
 
-| Package | Description |
-|---|---|
-| [`@rsc-boundary/core`](packages/core) | Framework-agnostic: fiber walk, highlighting engine, devtools UI, adapter contract |
-| [`@rsc-boundary/next`](packages/next) | Next.js App Router adapter + `RscBoundaryProvider` |
-| [`@rsc-boundary/start`](packages/start) | TanStack Start adapter + `RscBoundaryProvider` |
+| Package                                 | Description                                                                        |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| [`@rsc-boundary/core`](packages/core)   | Framework-agnostic: fiber walk, highlighting engine, devtools UI, adapter contract |
+| [`@rsc-boundary/next`](packages/next)   | Next.js App Router adapter + `RscBoundaryProvider`                                 |
+| [`@rsc-boundary/start`](packages/start) | TanStack Start adapter + `RscBoundaryProvider`                                     |
 
 For behavior details, optional APIs (`RscDevtools`, explicit server markers), architecture, and limitations, read the per-package READMEs.
 
@@ -101,8 +101,8 @@ This repo includes coding-agent skills that walk through the integration steps:
 - **TanStack Start:** [`skills/install-start`](skills/install-start)
 
 ```bash
-npx skills add foxted/boundary --skill install-next
-npx skills add foxted/boundary --skill install-start
+npx skills add foxted/rsc-boundary --skill install-next
+npx skills add foxted/rsc-boundary --skill install-start
 ```
 
 ## Contributing

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true
   },
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
## Summary

- Adds `rewriteRelativeImportExtensions: true` to `packages/core/tsconfig.build.json`
- Fixes `ERR_MODULE_NOT_FOUND` errors when consuming `@rsc-boundary/core` in Node ESM environments (e.g. TanStack Start)

## Root Cause

The package is published as ESM (`"type": "module"`) and built with plain `tsc` using `moduleResolution: "bundler"`. That setting does not rewrite relative import paths in emitted output, so `./constants` stays extensionless in `dist/index.js`. Node's ESM resolver requires explicit `.js` extensions and fails to resolve those imports.

## Fix

`rewriteRelativeImportExtensions` (added in TypeScript 5.7) instructs `tsc` to append `.js` to relative imports in the emitted output, making the package consumable directly by Node's ESM resolver without a bundler.

## Test plan

- [ ] Build `@rsc-boundary/core` and verify `dist/index.js` imports have `.js` extensions
- [ ] Install the package in a TanStack Start app and confirm the `ERR_MODULE_NOT_FOUND` error is resolved

Made with [Cursor](https://cursor.com)