### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/foxted/rsc-boundary/security/code-scanning/1](https://github.com/foxted/rsc-boundary/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (top-level) so all jobs inherit minimal token scope unless overridden. For this CI pipeline, `contents: read` is sufficient for checkout and read-only operations.

Best single fix without changing functionality:
- Edit `.github/workflows/ci.yml`
- Insert, near the top-level keys (after `on` block is a clear location),:
  - `permissions:`
  - `  contents: read`

No imports, methods, or external definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
